### PR TITLE
Setup authorisation middleware

### DIFF
--- a/src/authorisation/checkPermission.ts
+++ b/src/authorisation/checkPermission.ts
@@ -1,0 +1,22 @@
+import { Request } from 'express';
+import { Role, PermissionContext } from './types';
+import { Permission, PERMISSIONS } from './permissions';
+import { hasRolePermission } from './roles';
+
+export const checkPermission = async (
+  userId: string,
+  role: Role,
+  permission: Permission,
+  req: Request
+): Promise<boolean> => {
+  // 1. Check if role has this permission
+  if (!hasRolePermission(role, permission)) {
+    return false;
+  }
+
+  // 2. Run granular permission check
+  const permissionHandler = PERMISSIONS[permission];
+  const context: PermissionContext = { userId, role, req };
+
+  return await permissionHandler(context);
+};

--- a/src/authorisation/permissions/finance.permissions.ts
+++ b/src/authorisation/permissions/finance.permissions.ts
@@ -1,0 +1,14 @@
+import { PermissionHandler } from '../types';
+
+const nothingElse = async () => true;
+
+export const financePermissions = {
+  'overview:view': nothingElse,
+  'project:update:own': async ({ req }) => {
+    req.params.projectId;
+    // Check if project belongs to user
+    // const project = await prisma.project.findUnique({ where: { id: projectId, createdById: userId } });
+    // return !!project;
+    return true; // Placeholder
+  },
+} satisfies Record<string, PermissionHandler>;

--- a/src/authorisation/permissions/index.ts
+++ b/src/authorisation/permissions/index.ts
@@ -1,0 +1,11 @@
+import { financePermissions } from './finance.permissions';
+import { PermissionHandler } from '../types';
+
+// note to developers: permission names should be defined as 'resource:action:own(optional)'
+
+export const PERMISSIONS = {
+  ...financePermissions,
+  // Add other permission groups here
+} satisfies Record<string, PermissionHandler>;
+
+export type Permission = keyof typeof PERMISSIONS;

--- a/src/authorisation/roles.ts
+++ b/src/authorisation/roles.ts
@@ -1,0 +1,37 @@
+import { Permission } from './permissions';
+import { Role } from './types';
+
+// Single layer hierarchy for convenience
+const roleHierarchy: Record<Role, Role[]> = {
+  superAdmin: ['generalManager', 'financeManager', 'partner'],
+  generalManager: ['partner'],
+  financeManager: ['partner'],
+  partner: [], // base role, no inheritance
+};
+
+// Role to permissions mapping
+const directPermissions: Record<Role, Permission[]> = {
+  //add more permissions here
+  superAdmin: ['overview:view', 'project:update:own'],
+
+  generalManager: [],
+
+  financeManager: [],
+
+  partner: [],
+};
+
+export const hasRolePermission = (
+  role: Role,
+  permission: Permission
+): boolean => {
+  // Check own permissions
+  if (directPermissions[role].includes(permission)) {
+    return true;
+  }
+
+  // Check inherited permissions
+  return roleHierarchy[role].some((inheritedRole) =>
+    directPermissions[inheritedRole].includes(permission)
+  );
+};

--- a/src/authorisation/types.ts
+++ b/src/authorisation/types.ts
@@ -1,0 +1,17 @@
+import { Request } from 'express';
+
+export type Role =
+  | 'superAdmin'
+  | 'generalManager'
+  | 'financeManager'
+  | 'partner';
+
+export type PermissionContext = {
+  userId: string;
+  role: Role;
+  req: Request;
+};
+
+export type PermissionHandler = (
+  context: PermissionContext
+) => Promise<boolean> | boolean;

--- a/src/middlewares/requirePermission.ts
+++ b/src/middlewares/requirePermission.ts
@@ -1,0 +1,52 @@
+import { Request, Response, NextFunction } from 'express';
+import { UnauthorizedError } from '../utils/errors';
+import { Permission } from '../authorisation/permissions';
+import { checkPermission } from '../authorisation/checkPermission';
+import { Role } from '../authorisation/types';
+
+const extractJWT = (_req: Request) => {
+  // TODO: Extract from actual JWT
+  const userId = 'user-123';
+  const role: Role = 'superAdmin';
+  return { userId, role };
+};
+
+export const requirePermission = (permission: Permission) => {
+  return async (req: Request, _res: Response, next: NextFunction) => {
+    try {
+      const { userId, role } = extractJWT(req);
+      const isAuthorized = await checkPermission(userId, role, permission, req);
+
+      if (!isAuthorized) {
+        throw new UnauthorizedError('Forbidden');
+      }
+
+      next();
+    } catch (error) {
+      next(error);
+    }
+  };
+};
+
+export const requireAnyPermission = (permissions: Permission[]) => {
+  return async (req: Request, _res: Response, next: NextFunction) => {
+    try {
+      const { userId, role } = extractJWT(req);
+      const results = await Promise.allSettled(
+        permissions.map((p) => checkPermission(userId, role, p, req))
+      );
+
+      const hasAnyPermission = results.some(
+        (result) => result.status === 'fulfilled' && result.value === true
+      );
+
+      if (!hasAnyPermission) {
+        throw new UnauthorizedError('Forbidden');
+      }
+
+      next();
+    } catch (error) {
+      next(error);
+    }
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2021"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
# Description

Worked on workflow for authorisation middleware checks at the route level.

## Changes Made
### 1. Implemented custom **authorisation handlers**:
`requirePermission` and `requireAnyPermission` takes in permissions to check for the request.
```
router.post(
  '/projects',
  validateRequest({ body: schema.ProjectSchema }),
  requirePermission('project:update:own')
  controller.createDisbursement
);
```
### 2. To Add More Permissions:
1. Define the permission in `authorisation/permissions/example.permissions.ts`. 
- A `PermissionHandler` is the function that executes for a more **granular check**, like on a specific resource.
- If your **permission is simple with no resource constraint** (_e.g. can view any project_), you can just define the `PermissionHandler` as `async() => true`. This means the granular check defaults to `true`.
```
const nothingElse = async () => true;

export const financePermissions = {
  'overview:view': nothingElse,
} satisfies Record<string, PermissionHandler>;
```
- If your **permission is complex with resource constraint** (_e.g. can only update **own** project_), this typically means that you need more granular checks. Citing this case as an example, you will need to compare the user's `id` with the project's `user_id`, which requires a db call. Hence, you can define the db check accordingly like:
```
export const financePermissions = {
  'project:update:own': async ({ req }) => {
    req.params.projectId;
    // Check if project belongs to user
    // const project = await prisma.project.findUnique({ where: { id: projectId, createdById: userId } });
    // return !!project;
    return true; // Placeholder
  },
} satisfies Record<string, PermissionHandler>;
```
2. Define which roles have this permission in `directPermissions` under `authorisation/roles.ts`. 
- Roles are hierarchical. This means that `superAdmin` will inherit all permissions of everyone else, `generalManager` will inherit all permissions of `partner` only, and `partner` inherits nothing. 
- Following **Principle of Least Privilege (PoLP)**, define the permission at the highest level possible. 
For example, don't give a `partner` access to viewing financial data, but rather give it to `financeManager` and `superAdmin` will naturally inherit the permission too.

## Checklist before requesting a review
- [y] I have performed a self-review of my code
- [na] If it is a core feature, I have added thorough tests.
